### PR TITLE
Add support for OSQA docker.  Admin script changes.

### DIFF
--- a/docker-compose-optional.yml
+++ b/docker-compose-optional.yml
@@ -1,0 +1,57 @@
+# IMPORTANT NOTE:
+# This docker-compose configuration is only for the Braven public website
+# and Braven Help.  It is setup and started using startall.bat.  To start
+# only the Portal, Join Server, SSO server use docker-compose.yml instead.
+
+
+#######################
+### Public facing Braven.org site
+#######################
+bravenweb:
+  image: wordpress
+  command: /var/www/html/docker-compose/scripts/run.bat
+  volumes:
+    - "./braven:/var/www/html"
+  links:
+    - bravendb
+  ports:
+    - "3005:3005"
+  environment:
+    WORDPRESS_DB_HOST: bravendb
+    WORDPRESS_DB_USER: wordpress
+    WORDPRESS_DB_PASSWORD: wordpress
+    WORDPRESS_DB_NAME: wordpress
+    VIRTUAL_HOST: braven.docker
+    VIRTUAL_PORT: 3005
+
+bravendb:
+  image: mysql:5.5.44
+  environment:
+    MYSQL_ROOT_PASSWORD: wordpress
+    MYSQL_USER: wordpress
+    MYSQL_PASSWORD: wordpress
+    MYSQL_DATABASE: wordpress
+    #MYSQL_ALLOW_EMPTY_PASSWORD: yes
+
+#######################
+###  OSQA (aka Braven Help)
+#######################
+helpweb:
+  build: ./osqa
+  command: /app/docker-compose/scripts/run.bat
+  volumes:
+    - "./osqa:/app"
+  links:
+    - helpdb
+  ports:
+    - "3006:3006"
+  environment:
+    VIRTUAL_HOST: help.docker
+    VIRTUAL_PORT: 3006
+
+helpdb:
+  image: postgres:9.3
+  environment:
+    POSTGRES_DB: osqa
+    POSTGRES_USER: root
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,33 +125,12 @@ cssjsweb:
   environment:
     VIRTUAL_HOST: cssjs.docker
 
-
-#######################
-### Public facing Braven.org site
-#######################
-bravenweb:
-  image: wordpress
-  command: /var/www/html/docker-compose/scripts/run.bat
-  volumes:
-    - "./braven:/var/www/html"
-  links:
-    - bravendb
-  ports:
-    - "3005:3005"
-  environment:
-    WORDPRESS_DB_HOST: bravendb
-    WORDPRESS_DB_USER: wordpress
-    WORDPRESS_DB_PASSWORD: wordpress
-    WORDPRESS_DB_NAME: wordpress
-    VIRTUAL_HOST: braven.docker
-    VIRTUAL_PORT: 3005
-
-bravendb:
-  image: mysql:5.5.44
-  environment:
-    MYSQL_ROOT_PASSWORD: wordpress
-    MYSQL_USER: wordpress
-    MYSQL_PASSWORD: wordpress
-    MYSQL_DATABASE: wordpress
-    #MYSQL_ALLOW_EMPTY_PASSWORD: yes
-
+# ------------------------------------
+######################################
+######################################
+# Running all these services is resource intensive, so by default we don't start
+# the Braven public website and Braven Help.  If you are developing something for one of those,
+# just use startall.bat instead of start.bat to start your local development environment.
+######################################
+######################################
+# ------------------------------------

--- a/restartall.bat
+++ b/restartall.bat
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose -f ./docker-compose.yml -f ./docker-compose-optional.yml restart || { echo >&2 "Error: docker-compose -f ./docker-compose.yml -f ./docker-compose-optional.yml restart failed."; exit 1; }

--- a/setup.bat
+++ b/setup.bat
@@ -31,7 +31,6 @@ bash_src_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 join_src_path="$( cd $bash_src_path; cd beyondz-platform && pwd )"
 canvas_src_path="$( cd $bash_src_path; cd canvas-lms && pwd )"
 sso_src_path="$( cd $bash_src_path; cd rubycas-server && pwd )"
-braven_src_path="$( cd $bash_src_path; cd braven && pwd )"
 
 vboxmanage --version &> /dev/null || { echo >&2 "VirtualBox not installed.  Please install it first"; exit 1; }
 vboxmanage list extpacks &> /dev/null || { echo >&2 "VirtualBox Extension pack not installed.  Please install it first"; exit 1; }
@@ -114,10 +113,9 @@ if [ "$(uname)" == "Darwin" ]; then
   cp -a ./beyondz-platform/docker-compose/db/seeds.rb ./beyondz-platform/db/
   cp -a ./canvas-lms/docker-compose/config/* ./canvas-lms/config/
   cp -a ./rubycas-server/docker-compose/config/* ./rubycas-server/config/
-  cp -a ./braven/docker-compose/config/wp-config.php ./braven/wp-config.php
 
   #docker-compose build --no-cache || { echo >&2 "Error: docker-compose build --no-cache failed."; exit 1; }
-  docker-compose build || { echo >&2 "Error: docker-compose build --no-cache failed."; exit 1; }
+  docker-compose build || { echo >&2 "Error: docker-compose build failed."; exit 1; }
 
   echo "Setting up Join development environment at: $join_src_path"
   cd $join_src_path
@@ -155,25 +153,16 @@ if [ "$(uname)" == "Darwin" ]; then
   echo "Setting up SSO development environment at: $sso_src_path"
   cd $sso_src_path
 
-  echo "Setting up Braven development environment at: $braven_src_path"
-  cd $braven_src_path
-
-  # Load a dev database with real info (uses the most recent production db migrated to a dev db)
-  # Note: the URLs, passwords, etc have been updated for use with dev before they were uploaded to
-  # the S3 bucket using the braven/docker-compose/scripts/migrate_prod_db.bat script on the updraftplus DB backup.
-  # Also, the braven-wp-content*.zip file was created to mimic the wp-content folder 
-  # using the updraftplus backups on dropbox (/<BeyondZ Dropbox>/Apps/UpdraftPlus/BeBraven
-  tmp_dir=docker-compose/tmp
-  mkdir $tmp_dir
-  rm $tmp_dir/braven*
-  aws s3 sync s3://beyondz-db-dumps/ $tmp_dir --exclude "*" --include "braven-*"
-  mv $tmp_dir/braven-wp-content*.zip $tmp_dir/braven-wp-content.zip
-  unzip -o $tmp_dir/braven-wp-content.zip || { echo >&2 "Error: failed extracting braven-wp-content.zip pulled from Amazon S3 into wp-content folder"; exit 1; }
-  find ./wp-content -type f -print0 | xargs -0 chmod 644
-  mv $tmp_dir/braven-dev-db*.gz $tmp_dir/braven-dev-db.gz
-  gzip -cd $tmp_dir/braven-dev-db.gz | docker-compose run --rm bravendb mysql -h bravendb -u wordpress "-pwordpress" wordpress || { echo >&2 "Error: failed loading development db for braven"; exit 1; }
-  rm -rf $tmp_dir
-  echo "http://braven.docker/wp-admin username/password is: beyondz/test1234"
+  # ------------------------------------------------
+  ##################################################
+  ##################################################
+  # Running all the services is resource intensive, so by default we don't setup / start
+  # the Braven public website and Braven Help.  If you are developing something for one of those,
+  # just use setupall.bat instead of setup.bat and startall.bat instead of start.bat to start your
+  # local development environment.
+  ##################################################
+  ##################################################
+  # ------------------------------------------------
 
   # OK, we're all set.  Let's start this bad boy.
   docker-compose up -d || { echo >&2 "Error: docker-compose up failed. A possible cause is that files use Windows newlines \(CRLF\). Check that all files in the docker-compose directory use Unix newlines \(LF\)."; exit 1; }

--- a/setupall.bat
+++ b/setupall.bat
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+./setup.bat
+
+braven_src_path="$( cd $bash_src_path; cd braven && pwd )"
+osqa_src_path="$( cd $bash_src_path; cd osqa && pwd )"
+
+if [ "$(uname)" == "Darwin" ]; then
+  # OS X platform
+
+  cp -a ./braven/docker-compose/config/wp-config.php ./braven/wp-config.php
+  cp -a ./osqa/docker-compose/config/settings_local.py ./osqa/settings_local.py
+
+  docker-compose -f ./docker-compose-optional.yml build || { echo >&2 "Error: docker-compose -f ./docker-compose-optional.yml build failed."; exit 1; }
+
+  echo "Setting up Braven development environment at: $braven_src_path"
+  cd $braven_src_path
+
+  # Load a dev database with real info (uses the most recent production db migrated to a dev db)
+  # Note: the URLs, passwords, etc have been updated for use with dev before they were uploaded to
+  # the S3 bucket using the braven/docker-compose/scripts/migrate_prod_db.bat script on the updraftplus DB backup.
+  # Also, the braven-wp-content*.zip file was created to mimic the wp-content folder 
+  # using the updraftplus backups on dropbox (/<BeyondZ Dropbox>/Apps/UpdraftPlus/BeBraven
+  tmp_dir=docker-compose/tmp
+  mkdir $tmp_dir
+  rm $tmp_dir/braven*
+  aws s3 sync s3://beyondz-db-dumps/ $tmp_dir --exclude "*" --include "braven-*"
+  mv $tmp_dir/braven-wp-content*.zip $tmp_dir/braven-wp-content.zip
+  unzip -o $tmp_dir/braven-wp-content.zip || { echo >&2 "Error: failed extracting braven-wp-content.zip pulled from Amazon S3 into wp-content folder"; exit 1; }
+  find ./wp-content -type f -print0 | xargs -0 chmod 644
+  mv $tmp_dir/braven-dev-db*.gz $tmp_dir/braven-dev-db.gz
+  gzip -cd $tmp_dir/braven-dev-db.gz | docker-compose run --rm bravendb mysql -h bravendb -u wordpress "-pwordpress" wordpress || { echo >&2 "Error: failed loading development db for braven"; exit 1; }
+  rm -rf $tmp_dir
+  echo "http://braven.docker/wp-admin username/password is: beyondz/test1234"
+
+  echo "Setting up OSQA development environment at: $osqa_src_path"
+  cd $osqa_src_path
+  cat docker-compose/config/braven_settings.sql | docker-compose run --rm helpweb psql -h helpdb -U root -d osqa
+  echo "IMPORTANT: You can login to Braven Help with any Braven Portal user and it will initialize them.  However, THE FIRST one you do this with becomes the Braven Help admin!!!"
+
+  # OK, we're all set.  Let's start this bad boy.
+  docker-compose -f ./docker-compose-optional.yml up -d || { echo >&2 "Error: docker-compose -f ./docker-compose-optional.yml up failed. A possible cause is that files use Windows newlines \(CRLF\). Check that all files in the docker-compose directory use Unix newlines \(LF\)."; exit 1; }
+
+
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  # GNU/Linux platform
+  echo "ERROR: setup script not written for Linux.  Please write it!"
+  exit 1;
+elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
+  # Windows NT platform
+  echo "ERROR: setup script not written for Windows.  Please write it!"
+  exit 1;
+fi
+
+echo "Setup complete!  Please start a new shell to get your environment variables"

--- a/startall.bat
+++ b/startall.bat
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$(uname)" == "Darwin" ]; then
+  # OS X platform
+  echo "Starting you local development environment for Mac"
+  dinghy up
+fi
+
+docker-compose -f ./docker-compose.yml -f docker-compose-optional.yml up -d || { echo >&2 "Error: docker-compose -f ./docker-compose.yml -f docker-compose-optional.yml up failed."; exit 1; }

--- a/stopall.bat
+++ b/stopall.bat
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+docker-compose -f ./docker-compose.yml -f ./docker-compose-optional.yml stop || { echo >&2 "Error: docker-compose -f ./docker-compose.yml -f ./docker-compose-optional.yml stop failed."; exit 1; }
+
+if [ "$(uname)" == "Darwin" ]; then
+  # OS X platform
+  echo "Stopping your local development environment for Mac"
+  dinghy halt
+fi
+
+


### PR DESCRIPTION
In addition to added OSQA for docker, this pull request splits the admin start, stop, and restart scripts into a lightweight and heavyweight version so you don't have to slow your local dev env to a halt if you aren't developing against Braven Help or the Braven public website.