### PR TITLE
Fixes Double Quote Matching Error for Host Echos

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -122,7 +122,7 @@ if [ "$(uname)" == "Darwin" ]; then
     echo 'Run this: sudo bash -c ''echo "127.0.0.1     cssjsweb" >> /etc/hosts'''
   fi
 
-  if ! grep -q "^[^#].*kitweb" /etc/hosts; then
+  if ! grep -q "^[^#].*kitsweb" /etc/hosts; then
     echo "########### TODO: #############"
     echo 'Run this: sudo bash -c ''echo "127.0.0.1     kitsweb" >> /etc/hosts'''
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -104,7 +104,7 @@ if [ "$(uname)" == "Darwin" ]; then
 
   if ! grep -q "^[^#].*joinweb" /etc/hosts; then
     echo "########### TODO: #############"
-    echo "Run this: sudo bash -c ''echo "127.0.0.1     joinweb" >> /etc/hosts'''
+    echo 'Run this: sudo bash -c ''echo "127.0.0.1     joinweb" >> /etc/hosts'''
   fi
 
   if ! grep -q "^[^#].*ssoweb" /etc/hosts; then
@@ -114,17 +114,17 @@ if [ "$(uname)" == "Darwin" ]; then
 
   if ! grep -q "^[^#].*canvasweb" /etc/hosts; then
     echo "########### TODO: #############"
-    echo "Run this: sudo bash -c ''echo "127.0.0.1     canvasweb" >> /etc/hosts'''
+    echo 'Run this: sudo bash -c ''echo "127.0.0.1     canvasweb" >> /etc/hosts'''
   fi
 
   if ! grep -q "^[^#].*cssjsweb" /etc/hosts; then
     echo "########### TODO: #############"
-    echo "Run this: sudo bash -c ''echo "127.0.0.1     cssjsweb" >> /etc/hosts'''
+    echo 'Run this: sudo bash -c ''echo "127.0.0.1     cssjsweb" >> /etc/hosts'''
   fi
 
   if ! grep -q "^[^#].*kitweb" /etc/hosts; then
     echo "########### TODO: #############"
-    echo "Run this: sudo bash -c ''echo "127.0.0.1     kitsweb" >> /etc/hosts'''
+    echo 'Run this: sudo bash -c ''echo "127.0.0.1     kitsweb" >> /etc/hosts'''
   fi
 
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then


### PR DESCRIPTION
Ran into this error when I removed host file changes:

```
./setup.sh: line 140: unexpected EOF while looking for matching `"'
./setup.sh: line 141: syntax error: unexpected end of file
```

Changed the first double quote to single quote and the error goes away.
```
########### TODO: #############
Run this: sudo bash -c echo "127.0.0.1     joinweb" >> /etc/hosts
########### TODO: #############
Run this: sudo bash -c echo "127.0.0.1     ssoweb" >> /etc/hosts
########### TODO: #############
Run this: sudo bash -c echo "127.0.0.1     canvasweb" >> /etc/hosts
########### TODO: #############
Run this: sudo bash -c echo "127.0.0.1     cssjsweb" >> /etc/hosts
########### TODO: #############
Run this: sudo bash -c echo "127.0.0.1     kitsweb" >> /etc/hosts
```