### PR TITLE
Remove awscli from install requirements

### DIFF
--- a/_setup_aws.sh
+++ b/_setup_aws.sh
@@ -1,16 +1,5 @@
 #!/bin/zsh
 
-# if ! aws --version &> /dev/null; then
-#   # Install AWS CLI if it's not there
-#   echo "Error: Please install 'aws'. E.g."
-#   echo "  $ pip3 install awscli"
-#   echo ""
-#   echo "If you don't have pip3, download and install Python 3x which has it: https://www.python.org/ftp/python/3.7.4/python-3.7.4-macosx10.9.pkg"
-#   echo ""
-#   echo "You MUST run 'aws configure' after to setup permissions, putting in your IAM Access and Secret Tokens. Use us-west-1 for the region."
-#   exit 1;
-# fi
-
 echo "Checking if the AWS ENV vars are setup"
 if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
   echo "The AWS ENV vars arent setup. TODO: add these to your .bash_profile"

--- a/_setup_aws.sh
+++ b/_setup_aws.sh
@@ -1,15 +1,15 @@
 #!/bin/zsh
 
-if ! aws --version &> /dev/null; then
-  # Install AWS CLI if it's not there
-  echo "Error: Please install 'aws'. E.g."
-  echo "  $ pip3 install awscli"
-  echo ""
-  echo "If you don't have pip3, download and install Python 3x which has it: https://www.python.org/ftp/python/3.7.4/python-3.7.4-macosx10.9.pkg"
-  echo ""
-  echo "You MUST run 'aws configure' after to setup permissions, putting in your IAM Access and Secret Tokens. Use us-west-1 for the region."
-  exit 1;
-fi
+# if ! aws --version &> /dev/null; then
+#   # Install AWS CLI if it's not there
+#   echo "Error: Please install 'aws'. E.g."
+#   echo "  $ pip3 install awscli"
+#   echo ""
+#   echo "If you don't have pip3, download and install Python 3x which has it: https://www.python.org/ftp/python/3.7.4/python-3.7.4-macosx10.9.pkg"
+#   echo ""
+#   echo "You MUST run 'aws configure' after to setup permissions, putting in your IAM Access and Secret Tokens. Use us-west-1 for the region."
+#   exit 1;
+# fi
 
 echo "Checking if the AWS ENV vars are setup"
 if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then

--- a/_setup_etc_hosts.sh
+++ b/_setup_etc_hosts.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 hosts_to_add=''
 while read git_info_line; do
@@ -28,5 +28,5 @@ then
     echo "$hosts_to_add" >> /etc/hosts
   fi
 else
-  echo "/etc/hosts is alread setup. Skipping!"
+  echo "/etc/hosts is already setup. Skipping!"
 fi


### PR DESCRIPTION
The awscli was needed to download database snapshots. This is no longer needed as it's done via Heroku now.
Also, on a fresh install I was testing, I realized the /etc/hosts script doesn't work for some reason using zsh, so I switched it back until I figure out what's going on.

Test Plan: ./setup.sh and got things on my Ubuntu system up and running